### PR TITLE
Support .where(sql())

### DIFF
--- a/sql-bricks.js
+++ b/sql-bricks.js
@@ -19,9 +19,17 @@
     this.vals = _.toArray(arguments).slice(1);
   }
   sql.prototype.toString = function toString(opts) {
-    if (opts && opts.parameterized)
-      opts.values = opts.values.concat(this.vals);
-    return this.str;
+    var str = this.str;
+    if (opts && opts.parameterized) {
+      this.vals.forEach(function(val) {
+        opts.values.push(val);
+        if (opts.placeholder == '$%d')
+          str = str.replace(/\$(?!\d)/, '$' + opts.value_ix++);
+        else if (opts.placeholder == '?%d')
+          str = str.replace(/\?(?!\d)/, '?' + opts.value_ix++);
+      });
+    }
+    return str;
   };
 
   // val() wrapper allows a value (string/number/etc) where SQL (column/table/etc) is expected
@@ -756,7 +764,7 @@
       return '(' + val._toString(opts) + ')';
 
     if (val instanceof sql)
-      return val.toString();
+      return val.toString(opts);
 
     if (opts.parameterized) {
       opts.values.push(val);

--- a/sql-bricks.js
+++ b/sql-bricks.js
@@ -517,7 +517,10 @@
       return typeof arg != 'object' || arg instanceof val || arg instanceof sql;
     });
     if (flat_args) {
-      return [sql.equal(args[0], args[1])];
+      if (args[0] instanceof sql && args[1] == null)
+        return [args[0]];
+      else
+        return [sql.equal(args[0], args[1])];
     }
     else {
       var exprs = [];

--- a/sql-bricks.js
+++ b/sql-bricks.js
@@ -526,10 +526,10 @@
 
   function argsToExpressions(args) {
     var flat_args = _.all(args, function(arg) {
-      return typeof arg != 'object' || arg instanceof val || arg instanceof sql;
+      return typeof arg != 'object' || arg instanceof val || arg instanceof sql || arg == null;
     });
     if (flat_args) {
-      if (args[0] instanceof sql && args[1] == null)
+      if (args[0] instanceof sql && args.length == 1)
         return [args[0]];
       else
         return [sql.equal(args[0], args[1])];

--- a/sql-bricks.js
+++ b/sql-bricks.js
@@ -13,10 +13,14 @@
   // it is also the main namespace for SQLBricks
   function sql(str) {
     if (!(this instanceof sql))
-      return new sql(str);
+      return applyNew(sql, arguments);
+
     this.str = str;
+    this.vals = _.toArray(arguments).slice(1);
   }
-  sql.prototype.toString = function toString() {
+  sql.prototype.toString = function toString(opts) {
+    if (opts && opts.parameterized)
+      opts.values = opts.values.concat(this.vals);
     return this.str;
   };
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -123,6 +123,10 @@ describe('SQL Bricks', function() {
         "SELECT * FROM time_limits WHERE tsrange(start_date_time, end_date_time, '[]') @> tsrange($1, $2, '[]')",
         ['2014-12-06T22:35:00', '2014-12-06T22:36:00']);
     });
+    it('should handle WHERE clauses with sql() and a null check', function() {
+      check(select().from('test').where(sql('my_col_val()'), null),
+        "SELECT * FROM test WHERE my_col_val() IS NULL");
+    });
     it('should not escape single quotes in the values returned by toParams()', function() {
       checkParams(update('user', {'name': "Muad'Dib"}),
         'UPDATE "user" SET name = $1',

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -118,7 +118,7 @@ describe('SQL Bricks', function() {
       var time1 = '2014-12-06T22:35:00';
       var time2 = '2014-12-06T22:36:00';
       stmt.where(sql(
-        "tsrange(start_date_time, end_date_time, '[]') @> tsrange($1, $2, '[]')", time1, time2));
+        "tsrange(start_date_time, end_date_time, '[]') @> tsrange($, $, '[]')", time1, time2));
       checkParams(stmt,
         "SELECT * FROM time_limits WHERE tsrange(start_date_time, end_date_time, '[]') @> tsrange($1, $2, '[]')",
         ['2014-12-06T22:35:00', '2014-12-06T22:36:00']);

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -113,6 +113,16 @@ describe('SQL Bricks', function() {
       check(stmt,
         "SELECT * FROM time_limits WHERE tsrange(start_date_time, end_date_time, '[]') @> tsrange($1, $2, '[]')");
     });
+    it('should generate WHERE clauses with arbitrary SQL and parameters', function() {
+      var stmt = select().from('time_limits');
+      var time1 = '2014-12-06T22:35:00';
+      var time2 = '2014-12-06T22:36:00';
+      stmt.where(sql(
+        "tsrange(start_date_time, end_date_time, '[]') @> tsrange($1, $2, '[]')", time1, time2));
+      checkParams(stmt,
+        "SELECT * FROM time_limits WHERE tsrange(start_date_time, end_date_time, '[]') @> tsrange($1, $2, '[]')",
+        ['2014-12-06T22:35:00', '2014-12-06T22:36:00']);
+    });
     it('should not escape single quotes in the values returned by toParams()', function() {
       checkParams(update('user', {'name': "Muad'Dib"}),
         'UPDATE "user" SET name = $1',

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -106,6 +106,13 @@ describe('SQL Bricks', function() {
       }), 'SELECT * FROM "user" WHERE removed = $1 AND name = $2',
       [0, 'Fred Flintstone']);
     });
+    it('should generate WHERE clauses with arbitrary SQL', function() {
+      var stmt = select().from('time_limits');
+      stmt.where(sql(
+        "tsrange(start_date_time, end_date_time, '[]') @> tsrange($1, $2, '[]')"));
+      check(stmt,
+        "SELECT * FROM time_limits WHERE tsrange(start_date_time, end_date_time, '[]') @> tsrange($1, $2, '[]')");
+    });
     it('should not escape single quotes in the values returned by toParams()', function() {
       checkParams(update('user', {'name': "Muad'Dib"}),
         'UPDATE "user" SET name = $1',


### PR DESCRIPTION
This is an attempt at addressing #60 (and, originally, https://github.com/Suor/sql-bricks-postgres/issues/2).

@sandfox, @Suor: I tried doing `.where(sql(...))` and it generated `WHERE ... IS NULL`. So I stepped through the code and found that SQL-Bricks supports two WHERE APIs: `.where({key: value})` and `.where(key, value)`. Since an object wasn't passed, sql-bricks thought we were attempting the 2nd API, and since there was no 2nd argument, sql-bricks interpreted it as a null.

In 47fc522, I added support for passing a single `sql()` literal. This made my test pass.

@Suor: In your example, you have parameters being passed to `sql()` as additional arguments.... this would be consistent with the other `.where()` uses, since they allow you to pass parameters -- I probably should add that too, since as it is you have to manually add the parameter values after SQL-Bricks generates the SQL string, but before it gets sent to postgres.