### PR TITLE
Support for JOIN USING

### DIFF
--- a/index.html
+++ b/index.html
@@ -161,6 +161,7 @@
       <li>- <a href="#selfrom">from</a></li>
       <li>- <a href="#join">join, leftJoin, rightJoin, fullJoin, crossJoin</a></li>
       <li>- <a href="#on">on</a></li>
+      <li>- <a href="#using">using</a></li>
       <li>- <a href="#selwhere">where</a></li>
       <li>- <a href="#groupBy">groupBy</a></li>
       <li>- <a href="#having">having</a></li>
@@ -374,6 +375,24 @@ select('*').from('person').innerJoin('address').on('person.addr_id', 'address.id
 
 select('*').from('person').join('address').on({'person.addr_id': 'address.id'});
 // SELECT * FROM person INNER JOIN address ON person.addr_id = address.id
+</pre>
+      </p>
+      <p id="using">
+        <b class="header">using</b><code>sel.using(columnList)</code>
+        <br />
+        <p>Joins using <tt>USING</tt> instead of <tt>ON</tt>. <b>columnList</b> can be passed in as one or more string arguments, a comma-delimited string, or an array.</p>
+        <pre>
+select('*').from('person').innerJoin('address').using('address_id');
+// SELECT * FROM person INNER JOIN address USING (address_id)
+
+select('*').from('person').join('address').using('address_id', 'country_id');
+// SELECT * FROM person INNER JOIN address USING (address_id, country_id)
+
+select('*').from('person').join('address').using('address_id, country_id');
+// SELECT * FROM person INNER JOIN address USING (address_id, country_id)
+
+select('*').from('person').join('address').using(['address_id', 'country_id']);
+// SELECT * FROM person INNER JOIN address USING (address_id, country_id)
 </pre>
       </p>
       <p id="selwhere">

--- a/index.html
+++ b/index.html
@@ -381,6 +381,7 @@ select('*').from('person').join('address').on({'person.addr_id': 'address.id'});
         <b class="header">using</b><code>sel.using(columnList)</code>
         <br />
         <p>Joins using <tt>USING</tt> instead of <tt>ON</tt>. <b>columnList</b> can be passed in as one or more string arguments, a comma-delimited string, or an array.</p>
+
         <pre>
 select('*').from('person').innerJoin('address').using('address_id');
 // SELECT * FROM person INNER JOIN address USING (address_id)
@@ -392,6 +393,11 @@ select('*').from('person').join('address').using('address_id, country_id');
 // SELECT * FROM person INNER JOIN address USING (address_id, country_id)
 
 select('*').from('person').join('address').using(['address_id', 'country_id']);
+// SELECT * FROM person INNER JOIN address USING (address_id, country_id)
+</pre>
+        <p><i>Note: <b>columnList</b> can also be passed as the second argument to <tt>join</tt> - in which case it must be specified <b>as an array</b> of one or more string values.</i></p>
+        <pre>
+select('*').from('person').join('address', ['address_id', 'country_id']);
 // SELECT * FROM person INNER JOIN address USING (address_id, country_id)
 </pre>
       </p>

--- a/sql-bricks.js
+++ b/sql-bricks.js
@@ -109,6 +109,14 @@
     }
     return this;
   };
+  Select.prototype.using = function(columns) {
+    var last_join = this.joins[this.joins.length - 1];
+
+    if (_.isEmpty(last_join.on))
+      last_join.on = []; // Using _.isEmpty tolerates overwriting of empty {}.
+    last_join.on = _.union(last_join.on, argsToArray(arguments));
+    return this;
+  };
 
   Select.prototype.where = Select.prototype.and = function() {
     return this._addExpression(arguments, '_where');
@@ -481,6 +489,15 @@
         throw new Error('No join criteria supplied for "' + getAlias(tbl) + '" join');
     }
 
+    // Array value for on indicates join using "using", rather than "on".
+    if (_.isArray(on)) {
+      on = _.map(on, function (column) {
+        return handleColumn(column);
+      }).join(', ');
+      return this.type + ' JOIN ' + tbl + ' USING (' + on + ')';
+    }
+
+    // Join using "on".
     if (isExpr(on)) {
       on = on.toString(opts);
     }

--- a/sql-bricks.js
+++ b/sql-bricks.js
@@ -99,11 +99,13 @@
   });
   Select.prototype.on = function(on) {
     var last_join = this.joins[this.joins.length - 1];
+    if (_.isArray(last_join.on) && !_.isEmpty(last_join.on))
+      throw new Error('Error adding clause ON: ' + last_join.left_tbl + ' JOIN ' + last_join.tbl + ' already has a USING clause.');
     if (isExpr(on)) {
       last_join.on = on;
     }
     else {
-      if (!last_join.on)
+      if (!last_join.on || (_.isArray(last_join.on))) // Instantiate object, including if it's an empty array from .using().
         last_join.on = {};
       _.extend(last_join.on, argsToObject(arguments));
     }
@@ -111,6 +113,8 @@
   };
   Select.prototype.using = function(columns) {
     var last_join = this.joins[this.joins.length - 1];
+    if (!_.isEmpty(last_join.on) && !_.isArray(last_join.on))
+      throw new Error('Error adding clause USING: ' + last_join.left_tbl + ' JOIN ' + last_join.tbl + ' already has an ON clause.');
 
     if (_.isEmpty(last_join.on))
       last_join.on = []; // Using _.isEmpty tolerates overwriting of empty {}.

--- a/tests/doctests.js
+++ b/tests/doctests.js
@@ -116,6 +116,10 @@ select('*').from('person').join('address').using('address_id, country_id');
 check(select('*').from('person').join('address').using(['address_id', 'country_id']), "SELECT * FROM person INNER JOIN address USING (address_id, country_id)");
 });
 
+it("select('*').from('person').join('address', ['address_id', 'country_id']);", function() {
+check(select('*').from('person').join('address', ['address_id', 'country_id']), "SELECT * FROM person INNER JOIN address USING (address_id, country_id)");
+});
+
 it("select('*').from('person').where('first_name', 'Fred');", function() {
 check(select('*').from('person').where('first_name', 'Fred'), "SELECT * FROM person WHERE first_name = 'Fred'");
 });

--- a/tests/doctests.js
+++ b/tests/doctests.js
@@ -88,6 +88,34 @@ select('*').from('person').innerJoin('address').on('person.addr_id', 'address.id
 check(select('*').from('person').join('address').on({'person.addr_id': 'address.id'}), "SELECT * FROM person INNER JOIN address ON person.addr_id = address.id");
 });
 
+it("select('*').from('person').innerJoin('address').using('address_id');", function() {
+check(select('*').from('person').innerJoin('address').using('address_id'), "SELECT * FROM person INNER JOIN address USING (address_id)");
+});
+
+it("select('*').from('person').join('address').using('address_id', 'country_id');", function() {
+select('*').from('person').innerJoin('address').using('address_id');
+
+check(select('*').from('person').join('address').using('address_id', 'country_id'), "SELECT * FROM person INNER JOIN address USING (address_id, country_id)");
+});
+
+it("select('*').from('person').join('address').using('address_id, country_id');", function() {
+select('*').from('person').innerJoin('address').using('address_id');
+
+select('*').from('person').join('address').using('address_id', 'country_id');
+
+check(select('*').from('person').join('address').using('address_id, country_id'), "SELECT * FROM person INNER JOIN address USING (address_id, country_id)");
+});
+
+it("select('*').from('person').join('address').using(['address_id', 'country_id']);", function() {
+select('*').from('person').innerJoin('address').using('address_id');
+
+select('*').from('person').join('address').using('address_id', 'country_id');
+
+select('*').from('person').join('address').using('address_id, country_id');
+
+check(select('*').from('person').join('address').using(['address_id', 'country_id']), "SELECT * FROM person INNER JOIN address USING (address_id, country_id)");
+});
+
 it("select('*').from('person').where('first_name', 'Fred');", function() {
 check(select('*').from('person').where('first_name', 'Fred'), "SELECT * FROM person WHERE first_name = 'Fred'");
 });

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -544,6 +544,11 @@ describe('SQL Bricks', function() {
       check(select().from('usr').join('addr').on(eq('usr.addr_id', sql('addr.id'))),
         'SELECT * FROM "user" usr INNER JOIN address addr ON usr.addr_id = addr.id');
     });
+    it('should not proceed if .using() has already been used', function() {
+      assert.throws(function () {
+        select().from('t1').join('t2').using('id').on({'t1.t2_id':'t2.id'});
+      });
+    });
   });
 
   describe('.using()', function() {
@@ -561,6 +566,11 @@ describe('SQL Bricks', function() {
       check(select().from('usr').join('addr').using(['addr_id', 'contrived_id']),
         'SELECT * FROM "user" usr ' + 
         'INNER JOIN address addr USING (addr_id, contrived_id)');
+    });
+    it('should not proceed if .on() has already been used', function() {
+      assert.throws(function () {
+        select().from('t1').join('t2').on({'t1.t2_id':'t2.id'}).using('id');
+      });
     });
   });
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -517,7 +517,7 @@ describe('SQL Bricks', function() {
     });
   });
 
-  describe('on()', function() {
+  describe('.on()', function() {
     it('should accept an object literal', function() {
       check(select().from('usr').join('addr').on({'usr.addr_id': 'addr.id'}),
         'SELECT * FROM "user" usr ' + 
@@ -543,6 +543,24 @@ describe('SQL Bricks', function() {
     it('should accept an expression', function() {
       check(select().from('usr').join('addr').on(eq('usr.addr_id', sql('addr.id'))),
         'SELECT * FROM "user" usr INNER JOIN address addr ON usr.addr_id = addr.id');
+    });
+  });
+
+  describe('.using()', function() {
+    it('should accept a comma-delimited string', function() {
+      check(select().from('usr').join('addr').using('addr_id, contrived_id'),
+        'SELECT * FROM "user" usr ' + 
+        'INNER JOIN address addr USING (addr_id, contrived_id)');
+    });
+    it('should accept multiple arguments', function() {
+      check(select().from('usr').join('addr').using('addr_id', 'contrived_id'),
+        'SELECT * FROM "user" usr ' + 
+        'INNER JOIN address addr USING (addr_id, contrived_id)');
+    });
+    it('should accept an array literal', function() {
+      check(select().from('usr').join('addr').using(['addr_id', 'contrived_id']),
+        'SELECT * FROM "user" usr ' + 
+        'INNER JOIN address addr USING (addr_id, contrived_id)');
     });
   });
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -756,9 +756,13 @@ describe('SQL Bricks', function() {
       check(select('desc').from('usr'),
         'SELECT "desc" FROM "user" usr');
     });
-    it('in JOINs', function() {
+    it('in JOIN ONs', function() {
       check(select().from('usr').join('psn', {'usr.order': 'psn.order'}),
-        'SELECT * FROM "user" usr INNER JOIN person psn ON usr."order" = psn."order"')
+        'SELECT * FROM "user" usr INNER JOIN person psn ON usr."order" = psn."order"');
+    });
+    it('in JOIN USINGs', function() {
+      check(select().from('usr').join('psn').using('order'),
+        'SELECT * FROM "user" usr INNER JOIN person psn USING ("order")');
     });
     it('in INSERT', function() {
       check(insert('user').values({'order': 1}),

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -515,6 +515,10 @@ describe('SQL Bricks', function() {
       check(select().from('usr').join('addr', eq('usr.addr_id', sql('addr.id'))),
         'SELECT * FROM "user" usr INNER JOIN address addr ON usr.addr_id = addr.id');
     });
+    it('join() should accept an array for the on argument (for JOIN USING)', function() {
+      check(select().from('usr').join('addr', ['addr_id', 'country_id']),
+        'SELECT * FROM "user" usr INNER JOIN address addr USING (addr_id, country_id)');
+    });
   });
 
   describe('.on()', function() {


### PR DESCRIPTION
Adds support for `JOIN USING (column_list)`. This is done through a `.using()` method, or an array 2nd argument passed to `.join()`.