### PR TITLE
Support for NATURAL JOIN (on top of JOIN USING)

### DIFF
--- a/index.html
+++ b/index.html
@@ -161,6 +161,7 @@
       <li>- <a href="#selfrom">from</a></li>
       <li>- <a href="#join">join, leftJoin, rightJoin, fullJoin, crossJoin</a></li>
       <li>- <a href="#on">on</a></li>
+      <li>- <a href="#using">using</a></li>
       <li>- <a href="#selwhere">where</a></li>
       <li>- <a href="#groupBy">groupBy</a></li>
       <li>- <a href="#having">having</a></li>
@@ -374,6 +375,24 @@ select('*').from('person').innerJoin('address').on('person.addr_id', 'address.id
 
 select('*').from('person').join('address').on({'person.addr_id': 'address.id'});
 // SELECT * FROM person INNER JOIN address ON person.addr_id = address.id
+</pre>
+      </p>
+      <p id="using">
+        <b class="header">using</b><code>sel.using(columnList)</code>
+        <br />
+        <p>Joins using <tt>USING</tt> instead of <tt>ON</tt>. <b>columnList</b> can be passed in as one or more string arguments, a comma-delimited string, or an array.</p>
+        <pre>
+select('*').from('person').innerJoin('address').using('address_id');
+// SELECT * FROM person INNER JOIN address USING (address_id)
+
+select('*').from('person').join('address').using('address_id', 'country_id');
+// SELECT * FROM person INNER JOIN address USING (address_id, country_id)
+
+select('*').from('person').join('address').using('address_id, country_id');
+// SELECT * FROM person INNER JOIN address USING (address_id, country_id)
+
+select('*').from('person').join('address').using(['address_id', 'country_id']);
+// SELECT * FROM person INNER JOIN address USING (address_id, country_id)
 </pre>
       </p>
       <p id="selwhere">

--- a/index.html
+++ b/index.html
@@ -162,6 +162,7 @@
       <li>- <a href="#join">join, leftJoin, rightJoin, fullJoin, crossJoin</a></li>
       <li>- <a href="#on">on</a></li>
       <li>- <a href="#using">using</a></li>
+      <li>- <a href="#join">naturalJoin, naturalLeftJoin, naturalRightJoin, naturalFullJoin, naturalCrossJoin</a></li>
       <li>- <a href="#selwhere">where</a></li>
       <li>- <a href="#groupBy">groupBy</a></li>
       <li>- <a href="#having">having</a></li>
@@ -399,6 +400,17 @@ select('*').from('person').join('address').using(['address_id', 'country_id']);
         <pre>
 select('*').from('person').join('address', ['address_id', 'country_id']);
 // SELECT * FROM person INNER JOIN address USING (address_id, country_id)
+</pre>
+      </p>
+      <p id="naturaljoin">
+        <b class="header">naturalJoin, naturalLeftJoin, naturalRightJoin, naturalFullJoin, naturalCrossJoin</b><br />
+        <code>sel.naturalJoin(tbl)</code><br />
+        <span class="alias">Aliases: <b>naturalInnerJoin, naturalLeftOuterJoin, naturalRightOuterJoin, naturalFullOuterJoin</b></span>
+        <br />
+        <p>Adds the specified natural join to the query. <b>tbl</b> can include an alias after a space or after the <tt>'AS'</tt> keyword (<tt>'my_table my_alias'</tt>).</p>
+        <pre>
+select().from('person').naturalJoin('address');
+// SELECT * FROM person NATURAL INNER JOIN address
 </pre>
       </p>
       <p id="selwhere">

--- a/index.html
+++ b/index.html
@@ -162,7 +162,7 @@
       <li>- <a href="#join">join, leftJoin, rightJoin, fullJoin, crossJoin</a></li>
       <li>- <a href="#on">on</a></li>
       <li>- <a href="#using">using</a></li>
-      <li>- <a href="#join">naturalJoin, naturalLeftJoin, naturalRightJoin, naturalFullJoin, naturalCrossJoin</a></li>
+      <li>- <a href="#naturaljoin">naturalJoin, naturalLeftJoin, naturalRightJoin, naturalFullJoin</a></li>
       <li>- <a href="#selwhere">where</a></li>
       <li>- <a href="#groupBy">groupBy</a></li>
       <li>- <a href="#having">having</a></li>
@@ -361,6 +361,7 @@ update('person', {'first_name': 'Fred'}).where({'last_name': 'Flintstone'}).toPa
         <span class="alias">Aliases: <b>innerJoin, leftOuterJoin, rightOuterJoin, fullOuterJoin</b></span>
         <br />
         <p>Adds the specified join to the query. <b>tbl</b> can include an alias after a space or after the <tt>'AS'</tt> keyword (<tt>'my_table my_alias'</tt>). <b>onCriteria</b> is optional if a <a href="#joinCriteria">joinCriteria</a> function has been supplied.</p>
+        <p><i>Note: <b>crossJoin</b> will ignore any <b>onCriteria</b> argument, if supplied.</i></p>
         <pre>
 select().from('person').join('address', {'person.addr_id': 'address.id'});
 // SELECT * FROM person INNER JOIN address ON person.addr_id = address.id
@@ -403,7 +404,7 @@ select('*').from('person').join('address', ['address_id', 'country_id']);
 </pre>
       </p>
       <p id="naturaljoin">
-        <b class="header">naturalJoin, naturalLeftJoin, naturalRightJoin, naturalFullJoin, naturalCrossJoin</b><br />
+        <b class="header">naturalJoin, naturalLeftJoin, naturalRightJoin, naturalFullJoin</b><br />
         <code>sel.naturalJoin(tbl)</code><br />
         <span class="alias">Aliases: <b>naturalInnerJoin, naturalLeftOuterJoin, naturalRightOuterJoin, naturalFullOuterJoin</b></span>
         <br />

--- a/index.html
+++ b/index.html
@@ -381,6 +381,7 @@ select('*').from('person').join('address').on({'person.addr_id': 'address.id'});
         <b class="header">using</b><code>sel.using(columnList)</code>
         <br />
         <p>Joins using <tt>USING</tt> instead of <tt>ON</tt>. <b>columnList</b> can be passed in as one or more string arguments, a comma-delimited string, or an array.</p>
+
         <pre>
 select('*').from('person').innerJoin('address').using('address_id');
 // SELECT * FROM person INNER JOIN address USING (address_id)
@@ -392,6 +393,11 @@ select('*').from('person').join('address').using('address_id, country_id');
 // SELECT * FROM person INNER JOIN address USING (address_id, country_id)
 
 select('*').from('person').join('address').using(['address_id', 'country_id']);
+// SELECT * FROM person INNER JOIN address USING (address_id, country_id)
+</pre>
+        <p><i>Note: <b>columnList</b> can also be passed as the second argument to <tt>join</tt> - in which case it must be specified <b>as an array</b> of one or more string values.</i></p>
+        <pre>
+select('*').from('person').join('address', ['address_id', 'country_id']);
 // SELECT * FROM person INNER JOIN address USING (address_id, country_id)
 </pre>
       </p>

--- a/sql-bricks.js
+++ b/sql-bricks.js
@@ -109,6 +109,14 @@
     }
     return this;
   };
+  Select.prototype.using = function(columns) {
+    var last_join = this.joins[this.joins.length - 1];
+
+    if (_.isEmpty(last_join.on))
+      last_join.on = []; // Using _.isEmpty tolerates overwriting of empty {}.
+    last_join.on = _.union(last_join.on, argsToArray(arguments));
+    return this;
+  };
 
   Select.prototype.where = Select.prototype.and = function() {
     return this._addExpression(arguments, '_where');
@@ -481,6 +489,15 @@
         throw new Error('No join criteria supplied for "' + getAlias(tbl) + '" join');
     }
 
+    // Array value for on indicates join using "using", rather than "on".
+    if (_.isArray(on)) {
+      on = _.map(on, function (column) {
+        return handleColumn(column);
+      }).join(', ');
+      return this.type + ' JOIN ' + tbl + ' USING (' + on + ')';
+    }
+
+    // Join using "on".
     if (isExpr(on)) {
       on = on.toString(opts);
     }

--- a/sql-bricks.js
+++ b/sql-bricks.js
@@ -99,11 +99,13 @@
   });
   Select.prototype.on = function(on) {
     var last_join = this.joins[this.joins.length - 1];
+    if (_.isArray(last_join.on) && !_.isEmpty(last_join.on))
+      throw new Error('Error adding clause ON: ' + last_join.left_tbl + ' JOIN ' + last_join.tbl + ' already has a USING clause.');
     if (isExpr(on)) {
       last_join.on = on;
     }
     else {
-      if (!last_join.on)
+      if (!last_join.on || (_.isArray(last_join.on))) // Instantiate object, including if it's an empty array from .using().
         last_join.on = {};
       _.extend(last_join.on, argsToObject(arguments));
     }
@@ -111,6 +113,8 @@
   };
   Select.prototype.using = function(columns) {
     var last_join = this.joins[this.joins.length - 1];
+    if (!_.isEmpty(last_join.on) && !_.isArray(last_join.on))
+      throw new Error('Error adding clause USING: ' + last_join.left_tbl + ' JOIN ' + last_join.tbl + ' already has an ON clause.');
 
     if (_.isEmpty(last_join.on))
       last_join.on = []; // Using _.isEmpty tolerates overwriting of empty {}.

--- a/sql-bricks.js
+++ b/sql-bricks.js
@@ -90,6 +90,10 @@
     'leftJoin': 'LEFT', 'leftOuterJoin': 'LEFT',
     'rightJoin': 'RIGHT', 'rightOuterJoin': 'RIGHT',
     'fullJoin': 'FULL', 'fullOuterJoin': 'FULL',
+    'naturalJoin': 'NATURAL INNER', 'naturalInnerJoin': 'NATURAL INNER',
+    'naturalLeftJoin': 'NATURAL LEFT', 'naturalLeftOuterJoin': 'NATURAL LEFT',
+    'naturalRightJoin': 'NATURAL RIGHT', 'naturalRightOuterJoin': 'NATURAL RIGHT',
+    'naturalFullJoin': 'NATURAL FULL', 'naturalFullOuterJoin': 'NATURAL FULL',
     'crossJoin': 'CROSS'
   };
   Object.keys(join_methods).forEach(function(method) {
@@ -486,6 +490,13 @@
   };
   Join.prototype.toString = function toString(opts) {
     var on = this.on, tbl = handleTable(this.tbl, opts), left_tbl = handleTable(this.left_tbl, opts);
+
+    // Natural or cross join, no criteria needed.
+    // Debt: Determining whether join is natural/cross by reading the string is slightly hacky... but works.
+    if (/^(natural|cross)/i.test(this.type))
+      return this.type + ' JOIN ' + tbl;
+    
+    // Not a natural or cross, check for criteria.
     if (!on || _.isEmpty(on)) {
       if (sql._joinCriteria)
         on = this.autoGenerateOn(tbl, left_tbl);

--- a/tests/doctests.js
+++ b/tests/doctests.js
@@ -120,6 +120,10 @@ it("select('*').from('person').join('address', ['address_id', 'country_id']);", 
 check(select('*').from('person').join('address', ['address_id', 'country_id']), "SELECT * FROM person INNER JOIN address USING (address_id, country_id)");
 });
 
+it("select().from('person').naturalJoin('address');", function() {
+check(select().from('person').naturalJoin('address'), "SELECT * FROM person NATURAL INNER JOIN address");
+});
+
 it("select('*').from('person').where('first_name', 'Fred');", function() {
 check(select('*').from('person').where('first_name', 'Fred'), "SELECT * FROM person WHERE first_name = 'Fred'");
 });

--- a/tests/doctests.js
+++ b/tests/doctests.js
@@ -116,6 +116,10 @@ select('*').from('person').join('address').using('address_id, country_id');
 check(select('*').from('person').join('address').using(['address_id', 'country_id']), "SELECT * FROM person INNER JOIN address USING (address_id, country_id)");
 });
 
+it("select('*').from('person').join('address', ['address_id', 'country_id']);", function() {
+check(select('*').from('person').join('address', ['address_id', 'country_id']), "SELECT * FROM person INNER JOIN address USING (address_id, country_id)");
+});
+
 it("select('*').from('person').where('first_name', 'Fred');", function() {
 check(select('*').from('person').where('first_name', 'Fred'), "SELECT * FROM person WHERE first_name = 'Fred'");
 });

--- a/tests/doctests.js
+++ b/tests/doctests.js
@@ -88,6 +88,34 @@ select('*').from('person').innerJoin('address').on('person.addr_id', 'address.id
 check(select('*').from('person').join('address').on({'person.addr_id': 'address.id'}), "SELECT * FROM person INNER JOIN address ON person.addr_id = address.id");
 });
 
+it("select('*').from('person').innerJoin('address').using('address_id');", function() {
+check(select('*').from('person').innerJoin('address').using('address_id'), "SELECT * FROM person INNER JOIN address USING (address_id)");
+});
+
+it("select('*').from('person').join('address').using('address_id', 'country_id');", function() {
+select('*').from('person').innerJoin('address').using('address_id');
+
+check(select('*').from('person').join('address').using('address_id', 'country_id'), "SELECT * FROM person INNER JOIN address USING (address_id, country_id)");
+});
+
+it("select('*').from('person').join('address').using('address_id, country_id');", function() {
+select('*').from('person').innerJoin('address').using('address_id');
+
+select('*').from('person').join('address').using('address_id', 'country_id');
+
+check(select('*').from('person').join('address').using('address_id, country_id'), "SELECT * FROM person INNER JOIN address USING (address_id, country_id)");
+});
+
+it("select('*').from('person').join('address').using(['address_id', 'country_id']);", function() {
+select('*').from('person').innerJoin('address').using('address_id');
+
+select('*').from('person').join('address').using('address_id', 'country_id');
+
+select('*').from('person').join('address').using('address_id, country_id');
+
+check(select('*').from('person').join('address').using(['address_id', 'country_id']), "SELECT * FROM person INNER JOIN address USING (address_id, country_id)");
+});
+
 it("select('*').from('person').where('first_name', 'Fred');", function() {
 check(select('*').from('person').where('first_name', 'Fred'), "SELECT * FROM person WHERE first_name = 'Fred'");
 });

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -509,7 +509,7 @@ describe('SQL Bricks', function() {
     it('.crossJoin() should generate a cross join', function() {
       check(select().from('usr').crossJoin('addr'),
         'SELECT * FROM "user" usr ' + 
-        'CROSS JOIN address addr ON usr.addr_fk = addr.pk');
+        'CROSS JOIN address addr');
     });
     it('join() should accept an expression for the on argument', function() {
       check(select().from('usr').join('addr', eq('usr.addr_id', sql('addr.id'))),
@@ -614,11 +614,6 @@ describe('SQL Bricks', function() {
       check(select().from('usr').naturalFullOuterJoin('addr'),
         'SELECT * FROM "user" usr ' + 
         'NATURAL FULL JOIN address addr');
-    });
-    it('.naturalCrossJoin() should generate a natural cross join', function() {
-      check(select().from('usr').naturalCrossJoin('addr'),
-        'SELECT * FROM "user" usr ' + 
-        'NATURAL CROSS JOIN address addr');
     });
   });
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -578,6 +578,50 @@ describe('SQL Bricks', function() {
     });
   });
 
+  describe('natural joins', function() {
+    it('.naturalJoin() should accept a comma-delimited string', function() {
+      check(select().from('usr').naturalJoin('psn, addr'),
+        'SELECT * FROM "user" usr ' + 
+        'NATURAL INNER JOIN person psn ' +
+        'NATURAL INNER JOIN address addr');
+    });
+    it('.naturalLeftJoin() should generate a natural left join', function() {
+      check(select().from('usr').naturalLeftJoin('addr'),
+        'SELECT * FROM "user" usr ' + 
+        'NATURAL LEFT JOIN address addr');
+    });
+    it('.naturalLeftOuterJoin() should generate a natural left join', function() {
+      check(select().from('usr').naturalLeftOuterJoin('addr'),
+        'SELECT * FROM "user" usr ' + 
+        'NATURAL LEFT JOIN address addr');
+    });
+    it('.naturalRightJoin() should generate a natural right join', function() {
+      check(select().from('usr').naturalRightJoin('addr'),
+        'SELECT * FROM "user" usr ' + 
+        'NATURAL RIGHT JOIN address addr');
+    });
+    it('.naturalRightOuterJoin() should generate a natural right join', function() {
+      check(select().from('usr').naturalRightOuterJoin('addr'),
+        'SELECT * FROM "user" usr ' + 
+        'NATURAL RIGHT JOIN address addr');
+    });
+    it('.naturalFullJoin() should generate a natural full join', function() {
+      check(select().from('usr').naturalFullJoin('addr'),
+        'SELECT * FROM "user" usr ' + 
+        'NATURAL FULL JOIN address addr');
+    });
+    it('.naturalFullOuterJoin() should generate a natural full join', function() {
+      check(select().from('usr').naturalFullOuterJoin('addr'),
+        'SELECT * FROM "user" usr ' + 
+        'NATURAL FULL JOIN address addr');
+    });
+    it('.naturalCrossJoin() should generate a natural cross join', function() {
+      check(select().from('usr').naturalCrossJoin('addr'),
+        'SELECT * FROM "user" usr ' + 
+        'NATURAL CROSS JOIN address addr');
+    });
+  });
+
   describe('WHERE clauses', function() {
     it('should AND multiple where() criteria by default', function() {
       check(select().from('user').where({

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -544,6 +544,11 @@ describe('SQL Bricks', function() {
       check(select().from('usr').join('addr').on(eq('usr.addr_id', sql('addr.id'))),
         'SELECT * FROM "user" usr INNER JOIN address addr ON usr.addr_id = addr.id');
     });
+    it('should not proceed if .using() has already been used', function() {
+      assert.throws(function () {
+        select().from('t1').join('t2').using('id').on({'t1.t2_id':'t2.id'});
+      });
+    });
   });
 
   describe('.using()', function() {
@@ -561,6 +566,11 @@ describe('SQL Bricks', function() {
       check(select().from('usr').join('addr').using(['addr_id', 'contrived_id']),
         'SELECT * FROM "user" usr ' + 
         'INNER JOIN address addr USING (addr_id, contrived_id)');
+    });
+    it('should not proceed if .on() has already been used', function() {
+      assert.throws(function () {
+        select().from('t1').join('t2').on({'t1.t2_id':'t2.id'}).using('id');
+      });
     });
   });
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -517,7 +517,7 @@ describe('SQL Bricks', function() {
     });
   });
 
-  describe('on()', function() {
+  describe('.on()', function() {
     it('should accept an object literal', function() {
       check(select().from('usr').join('addr').on({'usr.addr_id': 'addr.id'}),
         'SELECT * FROM "user" usr ' + 
@@ -543,6 +543,24 @@ describe('SQL Bricks', function() {
     it('should accept an expression', function() {
       check(select().from('usr').join('addr').on(eq('usr.addr_id', sql('addr.id'))),
         'SELECT * FROM "user" usr INNER JOIN address addr ON usr.addr_id = addr.id');
+    });
+  });
+
+  describe('.using()', function() {
+    it('should accept a comma-delimited string', function() {
+      check(select().from('usr').join('addr').using('addr_id, contrived_id'),
+        'SELECT * FROM "user" usr ' + 
+        'INNER JOIN address addr USING (addr_id, contrived_id)');
+    });
+    it('should accept multiple arguments', function() {
+      check(select().from('usr').join('addr').using('addr_id', 'contrived_id'),
+        'SELECT * FROM "user" usr ' + 
+        'INNER JOIN address addr USING (addr_id, contrived_id)');
+    });
+    it('should accept an array literal', function() {
+      check(select().from('usr').join('addr').using(['addr_id', 'contrived_id']),
+        'SELECT * FROM "user" usr ' + 
+        'INNER JOIN address addr USING (addr_id, contrived_id)');
     });
   });
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -756,9 +756,13 @@ describe('SQL Bricks', function() {
       check(select('desc').from('usr'),
         'SELECT "desc" FROM "user" usr');
     });
-    it('in JOINs', function() {
+    it('in JOIN ONs', function() {
       check(select().from('usr').join('psn', {'usr.order': 'psn.order'}),
-        'SELECT * FROM "user" usr INNER JOIN person psn ON usr."order" = psn."order"')
+        'SELECT * FROM "user" usr INNER JOIN person psn ON usr."order" = psn."order"');
+    });
+    it('in JOIN USINGs', function() {
+      check(select().from('usr').join('psn').using('order'),
+        'SELECT * FROM "user" usr INNER JOIN person psn USING ("order")');
     });
     it('in INSERT', function() {
       check(insert('user').values({'order': 1}),

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -515,6 +515,10 @@ describe('SQL Bricks', function() {
       check(select().from('usr').join('addr', eq('usr.addr_id', sql('addr.id'))),
         'SELECT * FROM "user" usr INNER JOIN address addr ON usr.addr_id = addr.id');
     });
+    it('join() should accept an array for the on argument (for JOIN USING)', function() {
+      check(select().from('usr').join('addr', ['addr_id', 'country_id']),
+        'SELECT * FROM "user" usr INNER JOIN address addr USING (addr_id, country_id)');
+    });
   });
 
   describe('.on()', function() {


### PR DESCRIPTION
Addresses #64 and #66.

@prust I've gone with your recommendation of still leaving the join criteria mandatory, except on cross join.

Here are the nuances of this commit:

- Calling `.crossJoin('some_table')` without any *onCriteria* is now the expected use case.
- However calling crossJoin with a criteria (e.g. `.crossJoin('t2').on({'foo':'bar'})`) will not fail; it will just silently discard ON/USING. You may or may not wish to change this.
- Ditto with the natural joins.
- Otherwise, any other join will throw an error if there is no on/using criteria. 

```js
// Criteria discard example.
sql.select().from('t1').crossJoin('t2').on({'foo':'bar'})
/* SELECT * FROM t1 CROSS JOIN t2 */
```

_Note that this branch is based off the `join-using` branch._