### PR TITLE
Expose both "reserved" and the auto quoting character

### DIFF
--- a/sql-bricks.js
+++ b/sql-bricks.js
@@ -945,9 +945,11 @@
   sql._quoteColOrTbl = quoteColOrTbl;
 
   // auto-quote tbl & col names if they have caps or are reserved words
+  sql._autoQuoteChar = '"';
+  
   function autoQuote(str) {
     if (/^\w+$/.test(str) && (/[A-Z]/.test(str) || str in reserved))
-      return '"' + str + '"';
+      return sql._autoQuoteChar + str + sql._autoQuoteChar;
     return str;
   }
   sql._autoQuote = autoQuote;
@@ -956,7 +958,7 @@
   // SQLite: http://www.sqlite.org/lang_keywords.html
   var reserved = ['all', 'analyse', 'analyze', 'and', 'any', 'array', 'as', 'asc', 'asymmetric', 'authorization', 'both', 'case', 'cast', 'check', 'collate', 'collation', 'column', 'constraint', 'create', 'cross', 'current_catalog', 'current_date', 'current_role', 'current_time', 'current_timestamp', 'current_user', 'default', 'deferrable', 'desc', 'distinct', 'do', 'else', 'end', 'except', 'false', 'fetch', 'for', 'foreign', 'freeze', 'from', 'full', 'grant', 'group', 'having', 'ilike', 'in', 'initially', 'inner', 'intersect', 'into', 'is', 'isnull', 'join', 'lateral', 'leading', 'left', 'like', 'limit', 'localtime', 'localtimestamp', 'natural', 'not', 'notnull', 'null', 'offset', 'on', 'only', 'or', 'order', 'outer', 'over', 'overlaps', 'placing', 'primary', 'references', 'returning', 'right', 'select', 'session_user', 'similar', 'some', 'symmetric', 'table', 'then', 'to', 'trailing', 'true', 'union', 'unique', 'user', 'using', 'variadic', 'verbose', 'when', 'where', 'window', 'with', 'abort', 'action', 'add', 'after', 'all', 'alter', 'analyze', 'and', 'as', 'asc', 'attach', 'autoincrement', 'before', 'begin', 'between', 'by', 'cascade', 'case', 'cast', 'check', 'collate', 'column', 'commit', 'conflict', 'constraint', 'create', 'cross', 'current_date', 'current_time', 'current_timestamp', 'database', 'default', 'deferrable', 'deferred', 'delete', 'desc', 'detach', 'distinct', 'drop', 'each', 'else', 'end', 'escape', 'except', 'exclusive', 'exists', 'explain', 'fail', 'for', 'foreign', 'from', 'full', 'glob', 'group', 'having', 'if', 'ignore', 'immediate', 'in', 'index', 'indexed', 'initially', 'inner', 'insert', 'instead', 'intersect', 'into', 'is', 'isnull', 'join', 'key', 'left', 'like', 'limit', 'match', 'natural', 'no', 'not', 'notnull', 'null', 'of', 'offset', 'on', 'or', 'order', 'outer', 'plan', 'pragma', 'primary', 'query', 'raise', 'references', 'regexp', 'reindex', 'release', 'rename', 'replace', 'restrict', 'right', 'rollback', 'row', 'savepoint', 'select', 'set', 'table', 'temp', 'temporary', 'then', 'to', 'transaction', 'trigger', 'union', 'unique', 'update', 'using', 'vacuum', 'values', 'view', 'virtual', 'when', 'where'];
   reserved = _.object(reserved, reserved);
-
+  sql._reserved = reserved;
 
   function isPlainObject(val) {
     return _.isObject(val) && !_.isArray(val);


### PR DESCRIPTION
I am currently working on extending this module to implement proper support of MySQL.

Exposing both the array of reserved words and the auto-quoting character I will be able to escape keywords with the MySQL **"`"** character.

Could you please merge this?

Thanks.