### PR TITLE
allow cloning of statements using in with a subquery

### DIFF
--- a/sql-bricks.js
+++ b/sql-bricks.js
@@ -792,7 +792,10 @@
   }
   sql.In = In;
   In.prototype.clone = function clone() {
-    return new In(this.col, this.list.slice());
+    if (_.isArray(this.list))
+        return new In(this.col, this.list.slice());
+    else if (this.list instanceof Statement)
+        return new In(this.col, this.list.clone());
   };
   In.prototype.toString = function toString(opts) {
     var col_sql = handleColumn(this.col, opts);

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -943,6 +943,11 @@ describe('SQL Bricks', function() {
       ins.clone().values({'last_name': 'Flintstone'});
       check(ins, "INSERT INTO \"user\" (first_name) VALUES ('Fred')");
     });
+    it('should clone $in subqueries', function() {
+      var sel = select().from('user').where($in('first_name', select('first_name').from('user')));
+      sel.clone().where('last_name', 'Flintstone');
+      check(sel, "SELECT * FROM \"user\" WHERE first_name IN (SELECT first_name FROM \"user\")");
+    });
   });
 
   describe('the AS keyword', function() {


### PR DESCRIPTION
When cloning statements that utilize $in with a subquery statement, cloning was failing with `this.list.slice is not a function`.