### PR TITLE
fix: output `.noWait()` as 'NOWAIT'

### DIFF
--- a/index.html
+++ b/index.html
@@ -502,10 +502,10 @@ select().from('person').where({'last_name': 'Flintstone'}).union()
       <p id="forUpdate">
         <b class="header">forUpdate, noWait</b><code>sel.forUpdate([tbl, ...]) / sel.noWait()</code>
         <br />
-        <p>Add the <tt>FOR UPDATE</tt> clause to lock all selected records from all tables in the select (or just the tables specified), along with an optional <tt>NO WAIT</tt> at the end:</p>
+        <p>Add the <tt>FOR UPDATE</tt> clause to lock all selected records from all tables in the select (or just the tables specified), along with an optional <tt>NOWAIT</tt> at the end:</p>
         <pre>
 select('addr_id').from('person').forUpdate().of('addr_id').noWait();
-// SELECT addr_id FROM person FOR UPDATE OF addr_id NO WAIT
+// SELECT addr_id FROM person FOR UPDATE OF addr_id NOWAIT
 </pre>
       </p>
       

--- a/sql-bricks.js
+++ b/sql-bricks.js
@@ -313,7 +313,7 @@
   Select.defineClause('forUpdate', function(opts) {
     if (this._forUpdate)
       return `FOR UPDATE${this._of ? ` OF ${handleColumns(this._of, opts)}` : ''}` +
-        (this._noWait ? ' NO WAIT' : '');
+        (this._noWait ? ' NOWAIT' : '');
   });
 
 

--- a/tests/doctests.js
+++ b/tests/doctests.js
@@ -166,7 +166,7 @@ check(select().from('person').where({'last_name': 'Flintstone'}).union()  .sele
 });
 
 it("select('addr_id').from('person').forUpdate().of('addr_id').noWait();", function() {
-check(select('addr_id').from('person').forUpdate().of('addr_id').noWait(), "SELECT addr_id FROM person FOR UPDATE OF addr_id NO WAIT");
+check(select('addr_id').from('person').forUpdate().of('addr_id').noWait(), "SELECT addr_id FROM person FOR UPDATE OF addr_id NOWAIT");
 });
 
 it("insert('person', {'first_name': 'Fred', 'last_name': 'Flintstone'});", function() {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -374,9 +374,9 @@ describe('SQL Bricks', function() {
       check(select().from('user').forUpdate().of('user'),
         'SELECT * FROM "user" FOR UPDATE OF "user"');
     });
-    it('should support FOR UPDATE OF ... NO WAIT', function() {
+    it('should support FOR UPDATE OF ... NOWAIT', function() {
       check(select().from('user').forUpdate().of('user').noWait(),
-        'SELECT * FROM "user" FOR UPDATE OF "user" NO WAIT');
+        'SELECT * FROM "user" FOR UPDATE OF "user" NOWAIT');
     });
   });
 


### PR DESCRIPTION
was previously output as 'NO WAIT'

fixes https://github.com/CSNW/sql-bricks/issues/105