### PR TITLE
Fix clone of embedded literal sql

### DIFF
--- a/sql-bricks.js
+++ b/sql-bricks.js
@@ -23,6 +23,10 @@
     if (_.isArray(this.vals[0]))
       this.vals = this.vals[0];
   }
+  sql.prototype.clone = function clone() {
+    var args = [this.str].concat(this.vals);
+    return sql.apply(null, args);
+  };
   sql.setDefaultOpts = setDefaultOpts;
   function setDefaultOpts(opts) {
     default_opts = _.extend(default_opts, opts);

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -948,6 +948,15 @@ describe('SQL Bricks', function() {
       sel.clone().where('last_name', 'Flintstone');
       check(sel, "SELECT * FROM \"user\" WHERE first_name IN (SELECT first_name FROM \"user\")");
     });
+    it('should clone parameterized sub-expressions', function() {
+      checkParams(select().from('tbl').where(or(sql('a = $1', 444), sql('b = $1', 555), sql('c = $1', 666))).clone(),
+        'SELECT * FROM tbl WHERE a = $1 OR b = $2 OR c = $3',
+        [444, 555, 666]);
+    });
+    it('should clone non-parameterized sub-expressions', function() {
+      check(select().from('tbl').where(or(sql('a = 444'), sql('b = 555'), sql('c = 666'))).clone(),
+        'SELECT * FROM tbl WHERE a = 444 OR b = 555 OR c = 666');
+    });
   });
 
   describe('the AS keyword', function() {


### PR DESCRIPTION
This fixes #118, with a couple of tests to protect against regressions.

The docs [state that](http://csnw.github.io/sql-bricks/#sql) sql() should be used:

> somewhere that a value is expected (the right-hand side of WHERE criteria, or insert()/update() values)

and in these situations, `clone()` was working correctly because it doesn't clone values (which are typically immutable, though I suppose it's technically possible for someone to mutate a `sql()` literal).

But right after that, the docs give an example where `sql()` is used in a higher-level context -- not just as a value, but as the entire WHERE expression. It is in these cases that it was throwing the error, and this is what was fixed in this pull request.

I should probably update the docs to explicitly allow `sql()` in more contexts and should think a little harder about whether we really need/want that functionality in the big 3.x refactor (which may never happen, at this rate).