### PR TITLE
Add overrideable identifier preparation methods

### DIFF
--- a/tests/tests.js
+++ b/tests/tests.js
@@ -944,6 +944,59 @@ describe('SQL Bricks', function() {
     });
   });
 
+  describe('overriding _prepareTableIdentifier', function() {
+    var sql;
+    var oldFunc;
+    before('override _prepareTableIdentifier', function() {
+      sql = is_common_js ? require('../sql-bricks.js') : window.SqlBricks;
+      oldFunc = sql._prepareTableIdentifier;
+      sql._prepareTableIdentifier = function(expr, opts) {
+        if (typeof expr === 'string') {
+          var snake = expr.replace(/[A-Z]/g, l => `_${l.toLowerCase()}`).replace(/^_/, '');
+          return oldFunc(snake, opts);
+        }
+        return oldFunc(expr, opts);
+      };
+    });
+
+    after('restore _prepareTableIdentifier', function() {
+      sql._prepareTableIdentifier = oldFunc;
+    });
+    it('should allow camelCase conversions', function() {
+      check(sql.select('myColumn').from('myTable'),
+            'SELECT "myColumn" FROM my_table')
+    });
+  });
+
+  describe('overriding _prepareColumnIdentifier', function() {
+    var sql;
+    var oldFunc;
+    before('override _prepareColumnIdentifier', function() {
+      sql = is_common_js ? require('../sql-bricks.js') : window.SqlBricks;
+      oldFunc = sql._prepareColumnIdentifier;
+      sql._prepareColumnIdentifier = function(expr, opts) {
+        var snake = expr.replace(/[A-Z]/g, l => `_${l.toLowerCase()}`).replace(/^_/, '');
+        return oldFunc(snake, opts);
+      };
+    });
+
+    after('restore _prepareColumnIdentifier', function() {
+      sql._prepareColumnIdentifier = oldFunc;
+    });
+    it('should allow camelCase conversions', function() {
+      check(sql.select('myColumn').from('my_table'),
+            'SELECT my_column FROM my_table')
+    });
+    it('should not affect table names', function() {
+      check(sql.select('myColumn').from('myTable'),
+            'SELECT my_column FROM "myTable"')
+    });
+    it('should not affect functions', function() {
+      check(sql.select('COUNT(*)').from('myTable'),
+            'SELECT COUNT(*) FROM "myTable"')
+    });
+  });
+
   describe('_extension()', function() {
     it('should shield base', function() {
       var ext = sql._extension();


### PR DESCRIPTION
I'm using sql-bricks in [my library](https://github.com/ClaireNeveu/mysql-bricks-client) and I'd like to add support for automatically converting between snake_case and camelCase.

I've added two overrideable methods on `sql`: `sql._prepareTableIdentifier` and `sql._prepareColumnIdentifier`. By overriding these you can change the behavior of the auto-quoter or simply hook into that pipeline and then pass the identifier on. This is a global mutation which isn't ideal but it's the best we can do with the current state of sql-bricks.

I know there's rumblings about a rewrite that would make it easier to override via inheritance, but since that is a way off I think this would be an acceptable interim solution.

Matching issue: https://github.com/CSNW/sql-bricks/issues/101