### PR TITLE
Fix bug in _.clone() reimplementation, closes #135

### DIFF
--- a/sql-bricks.js
+++ b/sql-bricks.js
@@ -25,7 +25,7 @@
 
   function cloneObj(obj) {
     if (types.isArray(obj))
-      return [].concat(arr);
+      return [].concat(obj);
     else
       return extend({}, obj);
   }


### PR DESCRIPTION
This bug was found by @vileoleone and the fix was also suggested by @vileoleone in #135.

It fixes a bug introduced in #112 (affecting only v3.x of sql-bricks). v2.x of sql-bricks uses `_.clone()` which properly handles both arrays and objects.